### PR TITLE
Fixing registry call under *nix

### DIFF
--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -320,7 +320,8 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
           self.log.verbose("Installing single module "+ name+"@"+version+armsg);
           var installArgs = ['install', name+"@"+version];
           if (altRepository) {
-            installArgs.push('--registry "'+altRepository+'"');
+            installArgs.push('--registry');
+            installArgs.push(altRepository);
           }
           return self.npm(installArgs, cwd).then(function() {
             results.installed[name] = version;


### PR DESCRIPTION
To fix https://github.com/mariocasciaro/npm-workspace/issues/10

Adds `--registry` flag and the registry path as separate arguments, which are later fused under Windows.

Has been tested on CentOS and Windows 7.
