### PR TITLE
fix mocha to 2.1 as 2.2 breaks tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "chai": "^1.9.2",
-    "mocha": "^2.0.1"
+    "mocha": "2.1.*"
   },
   "keywords": [
     "npm",


### PR DESCRIPTION
Performing `npm install` installed mocha 2.2.1, but tests were failing due to a timeout error. I updated the package.json to fix mocha version to 2.1.* ( tests perform correctly with that version )