### PR TITLE
add option to create relative links to module

### DIFF
--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -19,7 +19,8 @@ self.cli = function() {
     .option('-c, --copy', 'Copy modules instead of linking')
     .option('-v, --verbose', 'Output verbose log')
     .option('-g, --remove-git', 'Remove .git directories during copy')
-    .option('-p, --production', 'Installs only dependencies (no devDependencies)');
+    .option('-p, --production', 'Installs only dependencies (no devDependencies)')
+    .option('-l, --relative', 'Create relative symlinks for modules instead of absolute ones');
 
   program
     .command('install')
@@ -302,7 +303,48 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
           }
         } else if(!fs.existsSync(dest)) {
           self.log.info("Creating link "+ dest +" -> " + mapping);
-          fs.symlinkSync(mapping, dest, "dir");
+          if (program.relative) {
+            var relPath;
+            
+            /* we should assure that we are not symlinking inside a symlink ( as
+               this breaks path calculations by node ).
+               Ex:
+                prj1 depends on prj2 that depends on prj3
+                .
+                ├── prj1
+                │   ├── node_modules
+                │   │   └── prj2 -> ../../prj2
+                │   └── package.json
+                ├── prj2
+                │   ├── node_modules
+                │   │   └── prj3 -> ../../../../prj3 ==> this is obviously wrong
+                │   └── package.json
+                ├── prj3
+                │   └── package.json
+                └── workspace.json
+             */
+            // if parent folder is called node_modules we can be in a linked module
+            if (path.basename(path.dirname(cwd)) == 'node_modules') {
+              // if we are in a module, last installed module will be our parent module, right?
+              var lastInstalled = path.basename(_.last(installed));
+              // search for parent module in to-be-linked modules
+              var linkedParent = _.find(workspaceDescriptor.links, function(p, n) { return n === lastInstalled; });
+              // if parent module is a linked module
+              if (linkedParent) {
+                // get current module full path
+                var currentFullPath = _.find(workspaceDescriptor.links, function(p, n) { return n === name; });
+                // get relative path between absolute parent module node_modules folder and current module
+                relPath = path.relative(path.join(linkedParent, 'node_modules'), currentFullPath);
+              }
+            } else {            
+              // if is not the case above simply symlink the old way
+              relPath = path.relative(path.dirname(dest), mapping);
+            }
+            // do it
+            fs.symlinkSync(relPath, dest, "dir");
+          } else {
+            fs.symlinkSync(mapping, dest, "dir");
+          }
         }
           
         //now we make sure we fully install this linked module
@@ -330,7 +372,7 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
       } else {
         self.log.verbose("Link only and no links found. Skipping "+name);
       }
-    });
+    }); 
   });
 
   return promise.then(function() {


### PR DESCRIPTION
As discussed in #13, implementation for relative module linking in workspace.

Tests are passing.

To test it: `npm-workspace install -l`