### PR TITLE
Connecting to stdout & stderr at all log levels

### DIFF
--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -28,7 +28,7 @@ self.cli = function() {
       self.install(process.cwd()).then(function() {
         console.log('[npm-workspace] Done, happy coding!');
       }).catch(function(err) {
-        console.log(err.stack + "\n[npm-workspace] Ooooops, it wasn\'t my fault, I swear");
+        console.log(err.stack + "\n[npm-workspace] Ooooops, it wasn't my fault, I swear");
       });
     });
     
@@ -39,7 +39,7 @@ self.cli = function() {
       self.clean(process.cwd()).then(function() {
         console.log('[npm-workspace] Done, happy coding!');
       }).catch(function(err) {
-        console.log(err.stack + "\n[npm-workspace] Ooooops, it wasn\'t my fault, I swear");
+        console.log(err.stack + "\n[npm-workspace] Ooooops, it wasn't my fault, I swear");
       });
     });
 
@@ -209,7 +209,6 @@ self.resolveLink = function(dir) {
   return dir;
 };
 
-
 /**
  * Launch the npm executable
  */
@@ -217,25 +216,27 @@ self.npm = function(args, cwd) {
   var options = {
     cwd: cwd.replace(/\\/g, "/")
   };
-  if(program.verbose) {
-    options.out = through2(function(chunk, enc, cb) {
+  options.out = through2(function(chunk, enc, cb) {
+    if(program.verbose) {
       this.push(chunk);
       process.stdout.write(chunk, enc, cb);
-    });
-    options.err = through2(function(chunk, enc, cb) {
+    }
+  });
+  options.err = through2(function(chunk, enc, cb) {
+    if(program.verbose) {
       this.push(chunk);
       process.stdout.write(chunk, enc, cb);
-    });
-  }
-  
+    }
+  });
+
   if (process.platform === "win32") {
     args = [ (args.join(" ")) ]; // npm 2.x on Windows doesn't handle multiple argument properly?
   }
-  
+
   return spawned('npm', args, options)
-    .catch(function(proc) {
-      console.error(proc.combined);
-    });
+  .catch(function(proc) {
+    console.error(proc.combined);
+  });
 };
 
 


### PR DESCRIPTION
This prevents some issues with gyp packages on Windows

Moved the `if (verbose)` check to inside the `options.out` and `options.err` functions. This seems to solve some node-gyp problems my team have been seeing on Node 4.0.0 to 4.1.2