### PR TITLE
Support '--recursive' flag

### DIFF
--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -19,7 +19,8 @@ self.cli = function() {
     .option('-c, --copy', 'Copy modules instead of linking')
     .option('-v, --verbose', 'Output verbose log')
     .option('-g, --remove-git', 'Remove .git directories during copy')
-    .option('-p, --production', 'Installs only dependencies (no devDependencies)');
+    .option('-p, --production', 'Installs only dependencies (no devDependencies)')
+    .option('-r, --recursive', 'Follow all subdirectory paths for modules');
 
   program
     .command('install')
@@ -78,6 +79,7 @@ self.log = {
 
 self.install = function(cwd, installed) {
   installed = installed || [];
+
   var wsDesc = self.getWorkspaceDescriptor(cwd, true, true);
   var ret = when.resolve();
   if(wsDesc) {
@@ -97,20 +99,40 @@ self.install = function(cwd, installed) {
 self.installWorkspace = function(cwd, installed) {
   self.log.info("Installing workspace " + cwd);
   installed = installed || [];
-  
+
   var promise = when.resolve();
-  var files = fs.readdirSync(cwd);
+  var files = self.descendantsExcludingNpmModules(cwd, program.recursive);
   _.each(files, function(file) {
     promise = promise.then(function() {
-      var fullName = path.resolve(cwd, file);
-      var stat = fs.statSync(fullName);
-      if(stat.isDirectory()) {
-        return self.install(fullName, installed);
-      }
+      return self.install(file, installed);
     });
   });
   return promise;
 };
+
+function onlyDirectories(f){return fs.statSync(f).isDirectory();}
+function resolveTo(dir){return function(file) {return path.resolve(dir, file);};}
+function flatten(arr) {
+  return arr.reduce(function (flat, toFlatten) {
+    return flat.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten);
+  }, []);
+}
+
+self.descendantsExcludingNpmModules = function descendantsExcludingNpmModules(cwd, recurse) {
+  if (["node_modules", "bower_components"].indexOf(path.basename(cwd)) > -1) return []; // skip very common package manager stores
+  if (path.basename(cwd).indexOf('.') == 0) return []; // skip hidden directories
+
+  var files = fs.readdirSync(cwd).map(resolveTo(cwd)).filter(onlyDirectories);
+  if (files.length < 1) return [];
+  if (recurse && files.length > 0) {
+    _.each(files, function(file) {
+      if (typeof (file) == 'string'){
+        files.push(descendantsExcludingNpmModules(file, recurse));
+      }
+    });
+  }
+  return flatten(files); // flatten tree into simple list
+}
 
 
 /**
@@ -340,7 +362,6 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
 };
 
 
-
 self.isRoot = function(root) {
   return path.resolve('/') === path.resolve(root);
 };
@@ -359,8 +380,7 @@ self.normalizeDescriptor = function(cwd, descriptor) {
   return descriptor;
 };
 
-
-
+// read the 'package.json' file in the current directory
 self.getPackageDescriptor = function(cwd, nothrow) {
   var fileDesc = path.resolve(cwd, 'package.json');
   if(fs.existsSync(fileDesc)) {
@@ -375,7 +395,7 @@ self.getPackageDescriptor = function(cwd, nothrow) {
   //don't go upper (for now)
 };
 
-
+// recurse up from current location to find 'workspace.json'
 self.getWorkspaceDescriptor = function(cwd, shallow, nothrow) {
   var fileDesc = path.resolve(cwd, DESCRIPTOR_NAME);
   if(fs.existsSync(fileDesc)) {

--- a/test/fixtures/installAndLinkTest/recurCheck/package.json
+++ b/test/fixtures/installAndLinkTest/recurCheck/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "prj4",
+  "version": "0.0.1",
+  "private": "true",
+  "dependencies": {
+    "when": "*"
+  }
+}

--- a/test/fixtures/installAndLinkTest/recurCheck/plugins/prj1/package.json
+++ b/test/fixtures/installAndLinkTest/recurCheck/plugins/prj1/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "prj1",
+  "version": "0.0.1",
+  "private": "true",
+  "dependencies": {
+    "graceful-fs": "*",
+    "prj2": "*"
+  }
+}


### PR DESCRIPTION
See https://github.com/mariocasciaro/npm-workspace/issues/19

Changes:
 - 'dot folders' such as '.git' are no longer traversed
 - 'node_modules' and 'bower_components' folders are not traversed
 - if recursive flag is set, npm-workspace will search all
    non-excluded descendent folders for modules to `npm i` and link.

Thanks,
Iain B.