### PR TITLE
Added recursion support for 'clean' command

### DIFF
--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -111,6 +111,7 @@ self.installWorkspace = function(cwd, installed) {
 };
 
 function onlyDirectories(f){return fs.statSync(f).isDirectory();}
+function noDotFolders(f){return path.basename(f).indexOf('.') !== 0;}
 function resolveTo(dir){return function(file) {return path.resolve(dir, file);};}
 function flatten(arr) {
   return arr.reduce(function (flat, toFlatten) {
@@ -122,7 +123,7 @@ self.descendantsExcludingNpmModules = function descendantsExcludingNpmModules(cw
   if (["node_modules", "bower_components"].indexOf(path.basename(cwd)) > -1) return []; // skip very common package manager stores
   if (path.basename(cwd).indexOf('.') == 0) return []; // skip hidden directories
 
-  var files = fs.readdirSync(cwd).map(resolveTo(cwd)).filter(onlyDirectories);
+  var files = fs.readdirSync(cwd).map(resolveTo(cwd)).filter(onlyDirectories).filter(noDotFolders);
   if (files.length < 1) return [];
   if (recurse && files.length > 0) {
     _.each(files, function(file) {
@@ -430,6 +431,7 @@ self.clean = function(cwd) {
   return ret;
 };
 
+function longestFirst(a,b){return b.length - a.length;}
 
 self.cleanWorkspace = function(cwd) {
   //let's be sure we are in a workspace
@@ -438,12 +440,11 @@ self.cleanWorkspace = function(cwd) {
   }
   self.log.info("Cleaning workspace " + cwd);
   
-  var files = fs.readdirSync(cwd);
+  var files = self.descendantsExcludingNpmModules(cwd, program.recursive);
+  files.sort(longestFirst); // less likely to break symlinks on Windows.
+
   _.each(files, function(file) {
-    var fullPath = path.resolve(cwd, file);
-    if(fs.statSync(fullPath).isDirectory()) {
-      self.cleanModule(fullPath);
-    }
+    self.cleanModule(file);
   });
 };
 


### PR DESCRIPTION
Also better supports dot-file directory exclusion in both `install` and `clean` commands.

This completes the `--recursive` flag support, which I only implemented for install -- this could leave users with a long chain of unlink problems on Windows when using `git clean -df`