### PR TITLE
Changes for npm version 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ This allows mixed registry sources until `@scope`s are fixed.
     - Otherwise, `npm install` all the remaining modules
 - For each module linked, install or link its `peerDependencies` (recursively)
 
+## npm compatibility
+
+`npm-workspace` should work with `npm` 1, 2 and 3. To support this `npm-workspace` plays a few tricks behind the scenes, including making temporary dummy packages for packages it will later link.
+
+The version of `npm` is checked at the start of an install. If it is not correctly detected, `npm` 2.x is assumed.
+
+The installation of Peer Dependencies depends partly on the `npm` version used, but linked peer dependencies should be correctly fulfilled.
+
+The following `npm` issues currently have direct work-arounds in `npm-workspace`:
+* https://github.com/npm/npm/issues/10343
+* https://github.com/npm/npm/issues/10348
+* https://github.com/npm/npm/issues/9999
+
 ## This is NOT
 
 - The ultimate solution to your Node.js development workflow/private modules/deployment/etc/etc/etc/

--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -7,10 +7,12 @@ var program = require('commander'),
   rimraf = require("rimraf"),
   through2 = require('through2'),
   spawned = require('spawned'),
+  child_process = require('child_process');
   _ = require('lodash');
 
 var DESCRIPTOR_NAME = "workspace.json";
 
+var npm_major_version = 0;
 var self = module.exports = {};
 
 self.cli = function() {
@@ -26,6 +28,12 @@ self.cli = function() {
     .command('install')
     .description('Install the package using local dirs')
     .action(function(){
+      try {
+        npm_major_version = +child_process.execSync('npm -v',{encoding:'utf8'}).split('.')[0];
+      } catch (err) {
+        console.log('[npm-workspace] Could not read npm version. Is npm in your path? '+err);
+      }
+
       self.install(process.cwd()).then(function() {
         console.log('[npm-workspace] Done, happy coding!');
       }).catch(function(err) {
@@ -167,8 +175,11 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
   self.log.verbose("Installing direct dependencies " + JSON.stringify(_.keys(allDeps)) + " for " 
     + packageDescriptor.name + "@" + packageDescriptor.version);
   
-  return self.installWorkspaceDependencies(cwd, allDeps, workspaceDescriptor, true, installed)
+  return self.installWorkspaceDependencies(cwd, allDeps, workspaceDescriptor, installed)
   .then(function() {
+    // skip deep peer dependencies if doing a production install
+    if (program.production) return;
+
     //For the links we have to be sure we manually process the peerDependencies (recursively)
     //since they are not processed by npm
     function processLinked(deps, processed) {
@@ -183,7 +194,9 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
       var promise = when.resolve();
       _.each(deps, function(version, link) {
         promise = promise.then(function() {
-          var linkPackage = require(path.resolve(nodeModulesDir, link, 'package.json'));
+          var pkgPath = path.resolve(nodeModulesDir, link, 'package.json');
+          if (!fs.existsSync(pkgPath)) { throw new Error('Invalid package at '+pkgPath); }
+          var linkPackage = require(pkgPath);
           
           if(!_.isEmpty(linkPackage.peerDependencies)) {
             //Install OR link peer dependencies
@@ -192,7 +205,7 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
               + linkPackage.name + "@" + linkPackage.version + " into " + cwd);
           }
           
-          return self.installWorkspaceDependencies(cwd, linkPackage.peerDependencies, workspaceDescriptor, false, installed)
+          return self.installWorkspaceDependencies(cwd, linkPackage.peerDependencies, workspaceDescriptor, installed)
           .then(function(newResults) {
             _.extend(newDeps, newResults.linked);
           });
@@ -208,17 +221,8 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
       });
     }
 
-    //check peer dependendies for linked modules only (others are installed with npm install)
+    //check peer dependencies for linked modules only
     return processLinked(_.pick(allDeps, _.keys(workspaceDescriptor.links)));
-  }).then(function() {
-    self.log.info("npm install "
-      + packageDescriptor.name + "@" + packageDescriptor.version + " for " + cwd);
-      
-    var args = ['install'];
-    if(program.production) {
-      args.push('--production');
-    }
-    return self.npm(args, cwd);
   });
 };
 
@@ -273,90 +277,159 @@ self.ensureNodeModules = function(cwd) {
   }
 };
 
+// splits each property of the dependencies object into its own object in an array
+// i.e. {'a':1, 'b':2} becomes [{'name':'a','version':1},{'name':'b', 'version':2}]
+function repack(obj) {
+  var outp = [];
+  Object.keys(obj||{}).forEach(function(k){
+    outp.push({name:k, version:obj[k]});
+  });
+  return outp;
+}
+
 
 /**
- * Install (of link), in a specific module, a set of dependencies
+ * Install (or link), in a specific module, a set of dependencies
  */
-self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescriptor, linkOnly, installed) {
-  dependencies = dependencies || [];
+self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescriptor, installed) {
+  dependencies = repack(dependencies);
+  var links = workspaceDescriptor.links || {};
+  var repos = workspaceDescriptor.repos || {};
   var results = {
     linked: {},
     installed: {}
   };
   var nodeModulesDir = path.resolve(cwd, 'node_modules');
-  
+
+  // group dependencies by kind, and add some extra meta data.
+  var linkDependencies = [];
+  var specialRepoDeps  = [];
+
+  dependencies.forEach(function(spec){
+    var dest = path.resolve(nodeModulesDir, spec.name);
+    if (links[spec.name]) {
+      linkDependencies.push({name:spec.name, version:spec.version, mapping:links[spec.name], dest:dest});
+    } else if (repos[spec.name]) {
+      specialRepoDeps.push({name:spec.name, version:spec.version, altRepository:repos[spec.name], dest:dest});
+    }
+  });
+
+  // To maintain compatibility with all npm versions up to 3, we do some odd things here
+  // (1) add packages from special repos
+  // (2) add dummy packages for anything that will be linked
+  // (3) do a normal `npm i`
+  // (4) remove the dummy packages and do the link/copy for real.
+
   var promise = when.resolve();
-  _.each(dependencies, function(version, name) {
+
+  // (1) add each of the special repo deps one-by-one
+  specialRepoDeps.forEach(function(item) {
     promise = promise.then(function() {
-      self.log.verbose("Processing module " + name + "@" + version + " for module " + cwd);
-      var mapping = workspaceDescriptor.links[name];
-      var altRepository = (workspaceDescriptor.repos || {})[name];
-      var dest = path.resolve(nodeModulesDir, name);
-      if(mapping) {
-        self.log.verbose("Found mapping for module " + name + "@" + version);
-        var promise = when.resolve();
-        
-        //don't override by default
-        if(program.copy) {
-          if(fs.existsSync(dest) && fs.lstatSync(dest).isSymbolicLink()) {
-            rimraf.sync(dest);
-          }
-          
-          if(!fs.existsSync(dest)) {
-            self.log.info("[npm-workspace] Copying "+ dest +" from " + mapping);
-            var deferred = when.defer();
-            ncp(mapping, dest, function (err) {
-              if (err) {
-                return deferred.reject(err);
-              }
-              deferred.resolve();
-            });
-            promise = deferred.promise.then(function() {
-              //remove .git if options say so
-              if(program.removeGit) {
-                self.log.info("Cleaning .git directory " + path.join(dest, '.git'));
-                rimraf.sync(path.join(dest, '.git'));
-                rimraf.sync(path.join(dest, '.gitignore'));
-              }
-              
-              if(program.production) {
-                rimraf.sync((path.join(dest, 'node_modules')));
-              }
-            });
-          }
-        } else if(!fs.existsSync(dest)) {
-          self.log.info("Creating link "+ dest +" -> " + mapping);
-          fs.symlinkSync(mapping, dest, "dir");
+      self.log.verbose("Installing single module "+ item.name+
+        "@"+item.version+" from "+item.altRepository + " for module " + cwd);
+
+      if(fs.existsSync(item.dest)) return self.log.verbose("Already exists. Skipping "+item.name);
+
+      var installArgs = ['install', item.name+'@"'+item.version+'"'];
+      installArgs.push('--registry');
+      installArgs.push(item.altRepository);
+
+      return self.npm(installArgs, cwd).then(function() {
+        results.installed[item.name] = item.version;
+      });
+    });
+  });
+
+  // (2) add a dummy package for any links
+  linkDependencies.forEach(function(item) {
+    promise = promise.then(function() {
+      self.log.verbose("Stubbing mapped module " + item.name + "@" + item.version + " for module " + cwd);
+      var exists = fs.existsSync(item.dest);
+      var pkgIsSymLink = exists && fs.lstatSync(item.dest).isSymbolicLink();
+
+      if (!exists || pkgIsSymLink) {
+        if(pkgIsSymLink) { rimraf.sync(item.dest); }
+
+        fs.mkdirSync(item.dest);
+        var realPkg = path.join(item.mapping, 'package.json');
+        var stubPkg = path.join(item.dest, 'package.json');
+        if (npm_major_version >= 3) {// make fake package in stub
+          fs.writeFileSync(stubPkg, '{}', 'utf8'); 
+        } else {// copy real package into stub (required for npm < 3)
+          fs.writeFileSync(stubPkg, fs.readFileSync(realPkg), 'utf8');
         }
-          
-        //now we make sure we fully install this linked module
-        return promise.then(function() {
-          return self.install(dest, installed);
-        }).then(function() {
-          results.linked[name] = version;
-        });
-        //remove if already exists
-        //rimraf.sync(linkDest);
-      } else if(!linkOnly || altRepository) {
-        //do not install if already there
-        if(!fs.existsSync(dest)) {
-          var armsg = (altRepository) ? (" from "+altRepository) : ("");
-          self.log.verbose("Installing single module "+ name+"@"+version+armsg);
-          var installArgs = ['install', name+"@"+version];
-          if (altRepository) {
-            installArgs.push('--registry');
-            installArgs.push(altRepository);
-          }
-          return self.npm(installArgs, cwd).then(function() {
-            results.installed[name] = version;
-          });
-        } else {self.log.verbose("Already exists. Skipping "+name);}
-      } else {
-        self.log.verbose("Link only and no links found. Skipping "+name);
+        fs.writeFileSync(path.join(item.dest, 'npm-workspace-stub'), '');
       }
     });
   });
 
+
+  // (3) install all the normal packages
+  promise = promise.then(function() {
+    self.log.info("npm install for " + cwd);
+      
+    var args = ['install'];
+    if(program.production) {
+      args.push('--production');
+    }
+
+    return self.npm(args, cwd);
+  })
+
+  // (4) finally link modules and install sub-dependencies.
+  linkDependencies.forEach(function(item) {
+    promise = promise.then(function() {
+      self.log.verbose("Processing mapped module " + item.name + "@" + item.version + " for module " + cwd);
+      var exists = fs.existsSync(item.dest);
+      var pkgIsSymLink = exists && fs.lstatSync(item.dest).isSymbolicLink();
+
+      //don't override by default
+      if(program.copy) {
+        // remove any existing symlinks
+        if(pkgIsSymLink) { rimraf.sync(item.dest); }
+        
+        // Check to see if this is a stub package. If so, delete and continue with the copy
+        var stubMarker = path.join(item.dest, 'npm-workspace-stub');
+        if(exists && fs.existsSync(stubMarker)) {
+          rimraf.sync(item.dest);
+        }
+
+        // copy if not already present
+        if(!fs.existsSync(item.dest)) {
+          self.log.info("Copying "+ item.dest +" from " + item.mapping);
+          var deferred = when.defer();
+          var copy = when.promise(function(resolve, reject){
+            ncp(item.mapping, item.dest, function (err) {
+              if (err) {
+                return reject(err);
+              }
+              //remove .git if options say so
+              if(program.removeGit) {
+                self.log.info("Cleaning .git directory " + path.join(item.dest, '.git'));
+                rimraf.sync(path.join(item.dest, '.git'));
+                rimraf.sync(path.join(item.dest, '.gitignore'));
+              }
+              resolve();
+            });
+          });
+          return copy;
+        }
+      } else if(/*not a copy, and */!pkgIsSymLink) {
+        rimraf.sync(item.dest); // remove dummy package
+
+        fs.symlinkSync(item.mapping, item.dest, "dir");
+        self.log.info("Created link "+ item.dest +" -> " + item.mapping);
+      }
+
+      //now we make sure we fully install this linked module
+    }).then(function() {
+      return self.install(item.dest, installed); // Future : only do this if we haven't seen it before
+    }).then(function() {
+      results.linked[item.name] = item.version;
+    });
+  });
+
+  // All install promises hooked up, return them to be run
   return promise.then(function() {
     return results;
   });

--- a/test/test.js
+++ b/test/test.js
@@ -27,9 +27,12 @@ function checkPrj1Install(isLink) {
   
   //is installed?
   expect(fs.existsSync(prjRoot + "/node_modules/prj2/node_modules/lodash")).to.be.true;
-  expect(fs.lstatSync(prjRoot + "/node_modules/prj2/node_modules/prj3").isSymbolicLink()).to.be[isLink];
-  
-  //a peer dep
+
+  if (isLink == "true") { // in npm v3+, prj3 will be flattened down to the same level as prj2 unless it is a link
+    expect(fs.lstatSync(prjRoot + "/node_modules/prj2/node_modules/prj3").isSymbolicLink()).to.be.true;
+  }
+
+  //a direct dep
   expect(fs.existsSync(prjRoot + "/node_modules/graceful-fs")).to.be.true;
   expect(fs.lstatSync(prjRoot + "/node_modules/graceful-fs").isSymbolicLink()).to.be.false;
   
@@ -38,9 +41,6 @@ function checkPrj1Install(isLink) {
   expect(fs.lstatSync(prjRoot + "/node_modules/prj3").isSymbolicLink()).to.be[isLink];
   //is installed?
   expect(fs.existsSync(prjRoot + "/node_modules/prj3/node_modules/when")).to.be.true;
-  
-  //a 2 level recursive peer
-  expect(fs.existsSync(prjRoot + "/node_modules/ncp")).to.be.true;
 }
 
 function checkPrj4Install() {
@@ -54,7 +54,7 @@ function checkRecursiveInstall(wanted) {
   //the main dep/linked
   if (wanted){
     expect(fs.existsSync(prjRoot + "/node_modules/prj2")).to.be.true;
-    expect(fs.existsSync(prjRoot + "/node_modules/lodash")).to.be.true;
+    expect(fs.existsSync(prjRoot + "/node_modules/graceful-fs")).to.be.true;
   } else {
     expect(fs.existsSync(prjRoot + "/node_modules")).to.be.false;
   }
@@ -92,7 +92,6 @@ describe('npm-workspace install', function() {
     });
   });
 
-  ////////////////////////////////////////
   it('should install and link a workspace in a deep subfolder with recursive flag (command line)', function(done) {
     var wsRoot = path.resolve(SANDBOX_DIR, "installAndLinkTest");
     var proc = spawn(NPM_WORKSPACE_EXE, ['install', '-r', '--remove-git'], {cwd: wsRoot});
@@ -110,7 +109,6 @@ describe('npm-workspace install', function() {
       }
     });
   });
-  //////////////////////////////////////// 
   
   it('should install and link a workspace (programmatically)', function(done) {
     var wsRoot = path.resolve(SANDBOX_DIR, "installAndLinkTest");


### PR DESCRIPTION
Hi Mario. Sorry to be flooding you with these PRs recently...

npm v3 has broken a few behaviours that `npm-workspace` relies on.

- **Peer dependencies:**
  These are no longer installed by default. When `npm-workspace`
  explicitly adds these, they remain functional. Test have been updated to
  reflect new behaviour.

- **Linked dependency flattening** ( https://github.com/npm/npm/issues/10343  and https://github.com/npm/npm/issues/10348 and  https://github.com/npm/npm/issues/9999 )
  npm v3 does not correctly install dependencies that are shared between a
  package and its sym-linked dependency.
  ```
  A
  +- B (linked)
  |  +- C
  +- C
  ```
  Should result in both `A` and `B` getting a copy of `C`, however it
  results in:
  ```
  A
  +- B (linked)
     +- C
  ```
  To work around this, npm-workspace now adds 'dummy' packages for ones it
  will link, then runs `npm i` then replaces the dummy packages with the
  real symlinks. This results in a complete and correct install.

Due to a change in the way npm checks versions after npm 3, the dummy
packages need to be different, so the npm version is read at the start
of an install.

I realise this is a pretty major (and weird) reworking of the install process. I've run it against two very large workspace projects, and all seems OK.

--Iain Ballard