### PR TITLE
windows specific quotes

### DIFF
--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -321,6 +321,8 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
   // (4) remove the dummy packages and do the link/copy for real.
 
   var promise = when.resolve();
+  var win = process.platform === "win32";
+  var q = (win)?('"'):(''); // quote around version spec if running windows.
 
   // (1) add each of the special repo deps one-by-one
   specialRepoDeps.forEach(function(item) {
@@ -330,7 +332,7 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
 
       if(fs.existsSync(item.dest)) return self.log.verbose("Already exists. Skipping "+item.name);
 
-      var installArgs = ['install', item.name+'@"'+item.version+'"'];
+      var installArgs = ['install', item.name+'@'+q+item.version+q];
       installArgs.push('--registry');
       installArgs.push(item.altRepository);
 


### PR DESCRIPTION
This quotes version specs when building command lines for Windows, but leaves them unquoted for Linux.
Addresses #25

Tested on Win7 and Ubuntu 15.10