### PR TITLE
Added a capability to post install packages when being installed via a workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ If you have a few dependencies that come from custom registries, you can add a `
 ```
 This allows mixed registry sources until `@scope`s are fixed.
 
+## Workspace only install scripts
+
+Sometimes it will be convenient to execute a script in your modules _only_ during the installation of your workspace.
+To do this, add a script named `npm-workspace:install` to the module's `package.json`:
+
+```javascript
+{
+    "scripts": {
+        "npm-workspace:install": "..."
+    }
+}
+```
+When you execute `npm-workspace install` the script will run after the module has been installed (in the same way that
+`install` or `postinstall` scripts are.
+
 ## Under the hood
 
 - It finds and parse the links from the nearest `workspace.json` up in the current directory tree.

--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -15,6 +15,8 @@ var DESCRIPTOR_NAME = "workspace.json";
 var npm_major_version = 0;
 var self = module.exports = {};
 
+var POSTINSTALL_SCRIPT = "npm-workspace:install";
+
 self.cli = function() {
   program
     .version(require("../package.json").version)
@@ -40,7 +42,7 @@ self.cli = function() {
         console.log(err.stack + "\n[npm-workspace] Ooooops, it wasn't my fault, I swear");
       });
     });
-    
+
   program
     .command('clean')
     .description('Clean packages')
@@ -99,7 +101,7 @@ self.install = function(cwd, installed) {
       return self.installModule(cwd, wsDesc, pkg, installed);
     });
   }
-  
+
   return ret;
 };
 
@@ -155,7 +157,7 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
   } else {
     installed.push(realDir);
   }
-  
+
   if(!workspaceDescriptor) {
     //get the UPPER descriptor, not the one directly in the dir
     workspaceDescriptor = self.getWorkspaceDescriptor(path.resolve(cwd, '../'));
@@ -163,18 +165,18 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
   if(!packageDescriptor) {
     packageDescriptor = self.getPackageDescriptor(cwd);
   }
-  
+
   self.ensureNodeModules(cwd);
   var nodeModulesDir = path.resolve(cwd, 'node_modules');
-  
+
   var allDeps = _.extend({}, packageDescriptor.dependencies);
   if(!program.production) {
     _.extend(allDeps, packageDescriptor.devDependencies);
   }
 
-  self.log.verbose("Installing direct dependencies " + JSON.stringify(_.keys(allDeps)) + " for " 
+  self.log.verbose("Installing direct dependencies " + JSON.stringify(_.keys(allDeps)) + " for "
     + packageDescriptor.name + "@" + packageDescriptor.version);
-  
+
   return self.installWorkspaceDependencies(cwd, allDeps, workspaceDescriptor, installed)
   .then(function() {
     // skip deep peer dependencies if doing a production install
@@ -189,7 +191,7 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
       if(!processed) {
         processed = _.clone(deps);
       }
-      
+
       var newDeps = {};
       var promise = when.resolve();
       _.each(deps, function(version, link) {
@@ -197,21 +199,21 @@ self.installModule = function(cwd, workspaceDescriptor, packageDescriptor, insta
           var pkgPath = path.resolve(nodeModulesDir, link, 'package.json');
           if (!fs.existsSync(pkgPath)) { throw new Error('Invalid package at '+pkgPath); }
           var linkPackage = require(pkgPath);
-          
+
           if(!_.isEmpty(linkPackage.peerDependencies)) {
             //Install OR link peer dependencies
             self.log.verbose("Installing peer dependencies " +
               JSON.stringify(_.keys(linkPackage.peerDependencies)) + " from "
               + linkPackage.name + "@" + linkPackage.version + " into " + cwd);
           }
-          
+
           return self.installWorkspaceDependencies(cwd, linkPackage.peerDependencies, workspaceDescriptor, installed)
           .then(function(newResults) {
             _.extend(newDeps, newResults.linked);
           });
         });
       });
-      
+
       return promise.then(function() {
         var diff = _.omit(newDeps, _.keys(processed));
         //update the global list
@@ -235,6 +237,17 @@ self.resolveLink = function(dir) {
   }
   return dir;
 };
+
+/**
+ * Runs the npm-workspace post install script if present in the module's package
+ */
+self.postInstallModule = function(packageDescriptor, cwd) {
+  if (!packageDescriptor.scripts || !packageDescriptor.scripts[POSTINSTALL_SCRIPT]) {
+    return;
+  }
+  self.log.info("npm run " + POSTINSTALL_SCRIPT + " for " + cwd);
+  self.npm(["run", POSTINSTALL_SCRIPT], cwd);
+}
 
 /**
  * Launch the npm executable
@@ -356,7 +369,7 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
         var realPkg = path.join(item.mapping, 'package.json');
         var stubPkg = path.join(item.dest, 'package.json');
         if (npm_major_version >= 3) {// make fake package in stub
-          fs.writeFileSync(stubPkg, '{}', 'utf8'); 
+          fs.writeFileSync(stubPkg, '{}', 'utf8');
         } else {// copy real package into stub (required for npm < 3)
           fs.writeFileSync(stubPkg, fs.readFileSync(realPkg), 'utf8');
         }
@@ -369,7 +382,7 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
   // (3) install all the normal packages
   promise = promise.then(function() {
     self.log.info("npm install for " + cwd);
-      
+
     var args = ['install'];
     if(program.production) {
       args.push('--production');
@@ -389,7 +402,7 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
       if(program.copy) {
         // remove any existing symlinks
         if(pkgIsSymLink) { rimraf.sync(item.dest); }
-        
+
         // Check to see if this is a stub package. If so, delete and continue with the copy
         var stubMarker = path.join(item.dest, 'npm-workspace-stub');
         if(exists && fs.existsSync(stubMarker)) {
@@ -421,6 +434,8 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
 
         fs.symlinkSync(item.mapping, item.dest, "dir");
         self.log.info("Created link "+ item.dest +" -> " + item.mapping);
+
+        self.postInstallModule(self.getPackageDescriptor(item.mapping), item.mapping);
       }
 
       //now we make sure we fully install this linked module
@@ -494,7 +509,7 @@ self.clean = function(cwd) {
     //we are in a workspace
     ret = when.resolve(self.cleanWorkspace(cwd));
   }
-  
+
   var pkg = self.getPackageDescriptor(cwd, true);
   if(pkg) {
     //we are in a module dir
@@ -502,7 +517,7 @@ self.clean = function(cwd) {
       return self.cleanModule(cwd);
     });
   }
-  
+
   return ret;
 };
 
@@ -514,7 +529,7 @@ self.cleanWorkspace = function(cwd) {
     return;
   }
   self.log.info("Cleaning workspace " + cwd);
-  
+
   var files = self.descendantsExcludingNpmModules(cwd, program.recursive);
   files.sort(longestFirst); // less likely to break symlinks on Windows.
 


### PR DESCRIPTION
If a packages' package.json contains a 'npm-workspace:install' script, then
it will be executed by npm-workspace when the package has been installed.
This allows packages to execute install scripts that execute only when the
package is installed via npm-workspace.