### PR TITLE
Adding npm packages one-by-one

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,7 @@ When you execute `npm-workspace install` the script will run after the module ha
 
 ## npm compatibility
 
-`npm-workspace` should work with `npm` 1, 2 and 3. To support this `npm-workspace` plays a few tricks behind the scenes, including making temporary dummy packages for packages it will later link.
-
-The version of `npm` is checked at the start of an install. If it is not correctly detected, `npm` 2.x is assumed.
+`npm-workspace` should work with `npm` 1, 2 and 3. To support this `npm-workspace` takes a conservative approach, with each dependency being added independently.
 
 The installation of Peer Dependencies depends partly on the `npm` version used, but linked peer dependencies should be correctly fulfilled.
 

--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -317,6 +317,7 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
   // group dependencies by kind, and add some extra meta data.
   var linkDependencies = [];
   var specialRepoDeps  = [];
+  var regularRepoDeps = [];
 
   dependencies.forEach(function(spec){
     var dest = path.resolve(nodeModulesDir, spec.name);
@@ -324,6 +325,8 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
       linkDependencies.push({name:spec.name, version:spec.version, mapping:links[spec.name], dest:dest});
     } else if (repos[spec.name]) {
       specialRepoDeps.push({name:spec.name, version:spec.version, altRepository:repos[spec.name], dest:dest});
+    } else {
+      regularRepoDeps.push({name:spec.name, version:spec.version, dest:dest});
     }
   });
 
@@ -355,46 +358,23 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
     });
   });
 
-  // (2) add a dummy package for any links
-  linkDependencies.forEach(function(item) {
+  // (2) install all the normal packages
+  regularRepoDeps.forEach(function(item) {
     promise = promise.then(function() {
-      self.log.verbose("Stubbing mapped module " + item.name + "@" + item.version + " for module " + cwd);
-      var exists = fs.existsSync(item.dest);
-      var pkgIsSymLink = exists && fs.lstatSync(item.dest).isSymbolicLink();
+      self.log.verbose("Installing single module "+ item.name+
+        "@"+item.version+" from default registry for module " + cwd);
 
-      if (!exists || pkgIsSymLink) {
-        if(pkgIsSymLink) { rimraf.sync(item.dest); }
+      if(fs.existsSync(item.dest)) return self.log.verbose("Already exists. Skipping "+item.name);
 
-        fs.mkdirSync(item.dest);
-        var realPkg = path.join(item.mapping, 'package.json');
-        var stubPkg = path.join(item.dest, 'package.json');
-        if (npm_major_version >= 3) {// make fake package in stub
-          fs.writeFileSync(stubPkg, '{}', 'utf8');
-        } else {// copy real package into stub (required for npm < 3)
-          fs.writeFileSync(stubPkg, fs.readFileSync(realPkg), 'utf8');
-        }
-        fs.writeFileSync(path.join(item.dest, 'npm-workspace-stub'), '');
-      }
+      var installArgs = ['install', item.name+'@'+q+item.version+q];
+
+      return self.npm(installArgs, cwd).then(function() {
+        results.installed[item.name] = item.version;
+      });
     });
   });
 
-
-  // (3) install all the normal packages
-  promise = promise.then(function() {
-    self.log.info("npm install for " + cwd);
-
-    var args = ['install'];
-    if(program.production) {
-      args.push('--production');
-    }
-
-    var result = self.npm(args, cwd);
-    self.postInstallModule(self.getPackageDescriptor(cwd), cwd);
-
-    return result;
-  })
-
-  // (4) finally link modules and install sub-dependencies.
+  // (3) finally link modules and install sub-dependencies.
   linkDependencies.forEach(function(item) {
     promise = promise.then(function() {
       self.log.verbose("Processing mapped module " + item.name + "@" + item.version + " for module " + cwd);
@@ -433,7 +413,7 @@ self.installWorkspaceDependencies = function(cwd, dependencies, workspaceDescrip
           return copy;
         }
       } else if(/*not a copy, and */!pkgIsSymLink) {
-        rimraf.sync(item.dest); // remove dummy package
+        if (exists) rimraf.sync(item.dest); // remove dummy package
 
         fs.symlinkSync(item.mapping, item.dest, "dir");
         self.log.info("Created link "+ item.dest +" -> " + item.mapping);

--- a/lib/npm-workspace.js
+++ b/lib/npm-workspace.js
@@ -12,7 +12,6 @@ var program = require('commander'),
 
 var DESCRIPTOR_NAME = "workspace.json";
 
-var npm_major_version = 0;
 var self = module.exports = {};
 
 var POSTINSTALL_SCRIPT = "npm-workspace:install";
@@ -30,12 +29,6 @@ self.cli = function() {
     .command('install')
     .description('Install the package using local dirs')
     .action(function(){
-      try {
-        npm_major_version = +child_process.execSync('npm -v',{encoding:'utf8'}).split('.')[0];
-      } catch (err) {
-        console.log('[npm-workspace] Could not read npm version. Is npm in your path? '+err);
-      }
-
       self.install(process.cwd()).then(function() {
         console.log('[npm-workspace] Done, happy coding!');
       }).catch(function(err) {


### PR DESCRIPTION
This is a change to resolve #31
Each package sourced from the standard registry is added individually, to give best compatibility for the various problematic versions of npm 3.